### PR TITLE
Add sorting on the scan manager list view

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ You provide a scan url to download and the software will do the rest.
 # What are the compatible scan websites ?
 
 Currently, the compatible website are:
+
 - www.scan-vf.net
 - www.anime-sama.fr
 
@@ -33,12 +34,14 @@ Just enter the url of the scan in the text field and click "Next". If the url is
 >If you encounter a case where you think the url is valid but an alert is triggered please open an issue and specify the url in it. That will help me to take into account possibilities I has not expected.
 
 #### Compatibles url
+
 In most of the case if you copy-paste the link of the first page of the scan you want to download it should work but depending on the website you may have more options.
 
 ##### Scan-vf.net
 
 >You can either provide directly the url of a chapter or the url of the book.<br>
 >Here is an example for both possibilities:
+>
 >- Url of a chapter: https://www.scan-vf.net/one_piece/chapitre-1/1.
 >- Url of a book: https://www.scan-vf.net/one_piece.
 
@@ -61,7 +64,6 @@ In this step the app will automatically look online to collect the data necessar
 Wait for the completion of the scan data retrieval, once it's done you will be able to click the finish button and the scan data will be added in the scan manager view.<br>
 
 <p align="center"><img src="ReadMe/mainWindowWithScans.png" width="768" height="450" alt="Screenshot of the scan manager window with some scan data"></p>
-
 
 ## Download scans
 

--- a/ScanNetDownloader/Logic/Helpers/GridViewSorter.cs
+++ b/ScanNetDownloader/Logic/Helpers/GridViewSorter.cs
@@ -1,0 +1,224 @@
+﻿using ScanNetDownloader.View.CustomControls;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace ScanNetDownloader.Logic.Helpers
+{
+    class GridViewSorter
+    {
+        #region Properties
+        // COMMAND PROPERTY
+        public static ICommand GetCommand(DependencyObject obj)
+        {
+            return (ICommand)obj.GetValue(CommandProperty);
+        }
+
+        public static void SetCommand(DependencyObject obj, ICommand value)
+        {
+            obj.SetValue(CommandProperty, value);
+        }
+
+        public static readonly DependencyProperty CommandProperty =
+            DependencyProperty.RegisterAttached("Command", typeof(ICommand), typeof(GridViewSorter),
+                new UIPropertyMetadata(null, (depObj, eventArgs) =>
+                {
+                    ItemsControl listView = depObj as ItemsControl;
+                    if (listView != null)
+                    {
+                        if (!GetAutoSort(listView)) // Only change ClickHandler when AutoSort is disabled
+                        {
+                            // Add Column Click Handler
+                            if (eventArgs.OldValue == null && eventArgs.NewValue != null)
+                            {
+                                listView.AddHandler(GridViewColumnHeader.ClickEvent, new RoutedEventHandler(ColumnHeader_Click));
+                            }
+
+                            // Remove Column Click Handler
+                            if (eventArgs.OldValue != null && eventArgs.NewValue == null)
+                            {
+                                listView.RemoveHandler(GridViewColumnHeader.ClickEvent, new RoutedEventHandler(ColumnHeader_Click));
+                            }
+                        }
+                    }
+                })
+            );
+
+        // AUTO SORT PROPERTY
+        public static bool GetAutoSort(DependencyObject obj)
+        {
+            return (bool)obj.GetValue(AutoSortProperty);
+        }
+
+        public static void SetAutoSort(DependencyObject obj, bool value)
+        {
+            obj.SetValue(AutoSortProperty, value);
+        }
+
+        public static readonly DependencyProperty AutoSortProperty =
+            DependencyProperty.RegisterAttached("AutoSort", typeof(bool), typeof(GridViewSorter),
+                new UIPropertyMetadata(false, (depObj, eventArgs) =>
+                {
+                    ItemsControl listView = depObj as ItemsControl;
+                    if (listView != null)
+                    {
+                        if (GetCommand(listView) == null) // Only change click handler if no command has been set
+                        {
+                            bool oldValue = (bool)eventArgs.OldValue;
+                            bool newValue = (bool)eventArgs.NewValue;
+
+                            // Add Click Handler when AutoSort is set to true
+                            if (!oldValue && newValue)
+                            {
+                                listView.AddHandler(GridViewColumnHeader.ClickEvent, new RoutedEventHandler(ColumnHeader_Click));
+                            }
+
+                            // Remove Click Handler when AutoSort is set to false
+                            if (oldValue && !newValue)
+                            {
+                                listView.RemoveHandler(GridViewColumnHeader.ClickEvent, new RoutedEventHandler(ColumnHeader_Click));
+                            }
+                        }
+                    }
+                })
+            );
+
+        // PROPERTY NAME PROPERTY
+        public static string GetPropertyName(DependencyObject obj)
+        {
+            return (string)obj.GetValue(PropertyNameProperty);
+        }
+
+        public static void SetPropertyName(DependencyObject obj, string value)
+        {
+            obj.SetValue(PropertyNameProperty, value);
+        }
+
+        public static readonly DependencyProperty PropertyNameProperty =
+            DependencyProperty.RegisterAttached("PropertyName", typeof(string), typeof(GridViewSorter), new UIPropertyMetadata(null));
+
+        #endregion
+
+        #region Column header click event Handler
+        private static void ColumnHeader_Click(object sender, RoutedEventArgs e)
+        {
+            GridViewColumnHeader headerClicked = e.OriginalSource as GridViewColumnHeader;
+            if (headerClicked != null)
+            {
+                string propertyName = GetPropertyName(headerClicked.Column);
+                if (!string.IsNullOrEmpty(propertyName))
+                {
+                    ListView listView = GetAncestor<ListView>(headerClicked);
+                    if (listView != null)
+                    {
+                        ICommand command = GetCommand(listView);
+                        if (command != null)
+                        {
+                            if (command.CanExecute(propertyName))
+                            {
+                                command.Execute(propertyName);
+                            }
+                        }
+                        else if (GetAutoSort(listView))
+                        {
+                            ApplySort(listView, propertyName);
+                        }
+                    }
+                }
+            }
+        }
+
+        public static T GetAncestor<T>(DependencyObject reference) where T : DependencyObject
+        {
+            DependencyObject parent = VisualTreeHelper.GetParent(reference);
+            while (!(parent is T)) // ? What happens if there is no parent that correspond to T ?
+            {
+                parent = VisualTreeHelper.GetParent(parent);
+            }
+
+            if (parent != null)
+            {
+                return (T)parent;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public static void ApplySort(ListView listView, string propertyName)
+        {
+            ICollectionView collectionView = listView.Items;
+            ListSortDirection direction = ListSortDirection.Ascending;
+            bool sameSortProperty = false;
+
+            if (collectionView.SortDescriptions.Count > 0)
+            {
+                SortDescription currentSort = collectionView.SortDescriptions[0];
+                sameSortProperty = currentSort.PropertyName == propertyName;
+                if (sameSortProperty)
+                {
+                    if (currentSort.Direction == ListSortDirection.Ascending)
+                    {
+                        direction = ListSortDirection.Descending;
+                    }
+                    else
+                    {
+                        direction = ListSortDirection.Ascending;
+                    }
+                }
+                collectionView.SortDescriptions.Clear();
+            }
+
+            if (!string.IsNullOrEmpty(propertyName))
+            {
+                collectionView.SortDescriptions.Add(new SortDescription(propertyName, direction));
+
+                // TODO: Transform this into a custom sort command instead of using AutoSort
+                // Add secondary sorting depending on the property passed + Only change ScanManagerListViewSortProperty if property is from a ScanItem
+                if (propertyName == nameof(ScanItem.BookName))
+                {
+                    Debug.WriteLine($"Sort by book name, then by ChapterId");
+                    collectionView.SortDescriptions.Add(new SortDescription(nameof(ScanItem.ChapterId), ListSortDirection.Ascending));
+
+                    if(!sameSortProperty)
+                    {
+                        Settings.Instance.ScanManagerListViewSortProperty = propertyName;
+                        Debug.WriteLine($"Call Save");
+                        Settings.Save();
+                    }
+                }
+                else if (propertyName == nameof(ScanItem.ChapterId))
+                {
+                    Debug.WriteLine($"Sort by chapterID, then by BookName");
+                    collectionView.SortDescriptions.Add(new SortDescription(nameof(ScanItem.BookName), ListSortDirection.Ascending));
+
+                    if (!sameSortProperty)
+                    {
+                        Settings.Instance.ScanManagerListViewSortProperty = propertyName;
+                        Debug.WriteLine($"Call Save");
+                        Settings.Save();
+                    }
+                }
+                else if (propertyName == nameof(ScanItem.IsSelectedForDownload) || propertyName == nameof(ScanItem.DownloadStatus) || propertyName == nameof(ScanItem.PagesCount) || propertyName == nameof(ScanItem.Website))
+                {
+                    Debug.WriteLine($"Sort by {propertyName}, then by BookName and then by chapterId");
+                    collectionView.SortDescriptions.Add(new SortDescription(nameof(ScanItem.BookName), ListSortDirection.Ascending));
+                    collectionView.SortDescriptions.Add(new SortDescription(nameof(ScanItem.ChapterId), ListSortDirection.Ascending));
+
+                    if (!sameSortProperty)
+                    {
+                        Settings.Instance.ScanManagerListViewSortProperty = propertyName;
+                        Debug.WriteLine($"Call Save");
+                        Settings.Save();
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/ScanNetDownloader/Logic/ScansLocalData.cs
+++ b/ScanNetDownloader/Logic/ScansLocalData.cs
@@ -24,7 +24,7 @@ namespace ScanNetDownloader.Logic
         public static void InitializeScansData()
         {
             Instance = LoadData(Constants.SCANSLOCALDATA_JSON_PATH);
-            Instance.Log();
+            //Instance.Log();
         }
 
         private static ScansLocalData LoadData(string jsonPath)

--- a/ScanNetDownloader/Logic/Settings.cs
+++ b/ScanNetDownloader/Logic/Settings.cs
@@ -47,7 +47,7 @@ namespace ScanNetDownloader.Logic
         /// Should the program pause the app and wait for an user input when an error is triggered (Default=True)
         /// A major error requiring user input bypass this and pause the app anyway
         /// </summary>
-        public bool ErrorPauseApp { get; set; } = true;
+        public bool ErrorPauseApp { get; set; } = false;
 
         /// <summary>
         /// Do you want to create a .cbz archive of every chapter downloaded (Default=True)

--- a/ScanNetDownloader/Logic/Settings.cs
+++ b/ScanNetDownloader/Logic/Settings.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using ScanNetDownloader.Logic.Helpers;
 using ScanNetDownloader.View;
+using ScanNetDownloader.View.CustomControls;
 using System.Diagnostics;
 using System.IO;
 
@@ -63,6 +64,11 @@ namespace ScanNetDownloader.Logic
         /// Should the program automatically open Settings.json when you need to check something in it (Default=True)
         /// </summary>
         public bool AutoOpenJsonWhenNecessary { get; set; } = true; // TODO: Do we still really need this, if yes add to optionsView
+
+        /// <summary>
+        /// Last property used to sort the ScanManager ListView, to use the same property next time we open the app
+        /// </summary>
+        public string ScanManagerListViewSortProperty { get; set; } = nameof(ScanItem.BookName);
 
         public static void InitializeAppSettings()
         {

--- a/ScanNetDownloader/ScanNetDownloader.csproj
+++ b/ScanNetDownloader/ScanNetDownloader.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
     <ApplicationIcon>Images\appIcon.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/ScanNetDownloader/ScanNetDownloader.csproj
+++ b/ScanNetDownloader/ScanNetDownloader.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
+    <AssemblyVersion>1.0.2.0</AssemblyVersion>
+    <FileVersion>1.0.2.0</FileVersion>
     <ApplicationIcon>Images\appIcon.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/ScanNetDownloader/View/CustomControls/ScanManagerView.xaml
+++ b/ScanNetDownloader/View/CustomControls/ScanManagerView.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:ScanNetDownloader.View.CustomControls"
+             xmlns:sorter="clr-namespace:ScanNetDownloader.Logic.Helpers"
              mc:Ignorable="d" 
              d:DesignHeight="660" d:DesignWidth="1280">
     
@@ -47,12 +48,13 @@
             </Button>
         </StackPanel>
 
-        <ListView Grid.Row="1" ItemContainerStyle="{StaticResource testForScanManager}" Name="listVwScans" ItemsSource="{Binding Source={StaticResource ScanItemsSource}, UpdateSourceTrigger=PropertyChanged}" SelectionMode="Single" HorizontalContentAlignment="Stretch" Background="{StaticResource Colors.LightGrey}" BorderThickness="0">
+        <ListView Grid.Row="1" ItemContainerStyle="{StaticResource testForScanManager}" Name="listVwScans" ItemsSource="{Binding Source={StaticResource ScanItemsSource}, UpdateSourceTrigger=PropertyChanged}" SelectionMode="Single" HorizontalContentAlignment="Stretch" Background="{StaticResource Colors.LightGrey}" BorderThickness="0"
+                  sorter:GridViewSorter.AutoSort="True">
             <ListView.View>
                 <GridView AllowsColumnReorder="True" ColumnHeaderContainerStyle="{StaticResource testColumnsHeader}">
 
                     <!--Select for download column-->
-                    <GridViewColumn Width="40" HeaderTemplate="{StaticResource gridHeaderCheckboxIcon}"> 
+                    <GridViewColumn Width="40" HeaderTemplate="{StaticResource gridHeaderCheckboxIcon}" sorter:GridViewSorter.PropertyName="IsSelectedForDownload"> 
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
                                 <CheckBox IsChecked="{Binding Path=IsSelectedForDownload}" ToolTip="Select this scan for download" HorizontalAlignment="Center" Margin="3 0 0 0"/>
@@ -61,7 +63,7 @@
                     </GridViewColumn>
                     
                     <!--Download status column-->
-                    <GridViewColumn Width="40" HeaderTemplate="{StaticResource gridHeaderDownloadIcon}">
+                    <GridViewColumn Width="40" HeaderTemplate="{StaticResource gridHeaderDownloadIcon}" sorter:GridViewSorter.PropertyName="DownloadStatus">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
                                 <Grid>
@@ -75,10 +77,10 @@
                     </GridViewColumn>
                     
                     <!--Book name column-->
-                    <GridViewColumn Header="Book name" DisplayMemberBinding="{Binding Path=BookName}" Width="470"/>
+                    <GridViewColumn Header="Book name" DisplayMemberBinding="{Binding Path=BookName}" Width="470" sorter:GridViewSorter.PropertyName="BookName"/>
                     
                     <!--Chapter column-->
-                    <GridViewColumn Header="Chapter" Width="100">
+                    <GridViewColumn Header="Chapter" Width="100" sorter:GridViewSorter.PropertyName="ChapterId">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
                                 <TextBlock Text="{Binding Path=ChapterId}" TextAlignment="Center" VerticalAlignment="Center"/>
@@ -87,7 +89,7 @@
                     </GridViewColumn>
                         
                     <!--Pages column-->
-                    <GridViewColumn Header="Pages" Width="100">
+                    <GridViewColumn Header="Pages" Width="100" sorter:GridViewSorter.PropertyName="PagesCount">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
                                 <TextBlock Text="{Binding Path=PagesCount}" TextAlignment="Center" VerticalAlignment="Center"/>
@@ -96,7 +98,7 @@
                     </GridViewColumn>
                         
                     <!--Website column-->
-                    <GridViewColumn Header="Website" Width="250">
+                    <GridViewColumn Header="Website" Width="250" sorter:GridViewSorter.PropertyName="Website">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
                                 <TextBlock Text="{Binding Path=Website}" TextAlignment="Center" VerticalAlignment="Center"/>

--- a/ScanNetDownloader/View/CustomControls/ScanManagerView.xaml.cs
+++ b/ScanNetDownloader/View/CustomControls/ScanManagerView.xaml.cs
@@ -1,23 +1,10 @@
 ﻿using ScanNetDownloader.Logic;
 using ScanNetDownloader.Logic.Helpers;
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using ScanNetDownloader.Logic.Helpers;
 
 namespace ScanNetDownloader.View.CustomControls
 {
@@ -76,6 +63,9 @@ namespace ScanNetDownloader.View.CustomControls
             {
                 RefreshScanListView(); // Populate listView based on the local data
                 // Note: Settings are refreshed at OptionsView Initialization
+
+                // Sort the list view using the book name alphabetical order
+                GridViewSorter.ApplySort(listVwScans, Settings.Instance.ScanManagerListViewSortProperty);
             }
 
             if (ScanListItems.Count == 0) stPanelNoScans.Visibility = Visibility.Visible;


### PR DESCRIPTION
Automatically sort the scan manager list view by book name
Add the possibility to sort with another column by clicking on the column header
Add a settings value to save the last column use for sorting between sessions